### PR TITLE
fix(ai): add break type as a newline [CLK-249630]

### DIFF
--- a/src/mdToDelta.ts
+++ b/src/mdToDelta.ts
@@ -139,6 +139,9 @@ export class MarkdownToQuill {
             delta.insert({ divider: true });
             delta.insert('\n');
             break;
+          case 'break':
+            delta.insert('\n');
+            break;
           case 'image':
             delta = delta.concat(
               this.embedFormat(

--- a/test/newline/01-newline-only.json
+++ b/test/newline/01-newline-only.json
@@ -1,0 +1,5 @@
+[
+  {
+    "insert": "Line one\nLine two\nLine three\n"
+  }
+]

--- a/test/newline/01-newline-only.md
+++ b/test/newline/01-newline-only.md
@@ -1,0 +1,3 @@
+Line one
+Line two
+Line three

--- a/test/newline/01-space-space-newline.json
+++ b/test/newline/01-space-space-newline.json
@@ -1,0 +1,5 @@
+[
+  {
+    "insert": "Line one\nLine two\nLine three\n"
+  }
+]

--- a/test/newline/01-space-space-newline.md
+++ b/test/newline/01-space-space-newline.md
@@ -1,0 +1,3 @@
+Line one  
+Line two  
+Line three


### PR DESCRIPTION
Fixed issue where `break` type was not being treated
as a newline.

`[space][space][newline]` was getting added as `type.break`.