### PR TITLE
feat: add uuid to linebreaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/md-to-quill-delta",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Markdown to Quill Delta",
   "main": "dist/umd/index.js",
   "module": "dist/mdToDelta.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/md-to-quill-delta",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Markdown to Quill Delta",
   "main": "dist/umd/index.js",
   "module": "dist/mdToDelta.js",
@@ -57,7 +57,8 @@
     "tslint-loader": "^3.5.4",
     "typescript": "^5.4.5",
     "webpack": "^5.91.0",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "uuid": "^8.3.2"
   },
   "dependencies": {
     "mdast-util-from-markdown": "^2.0.0",

--- a/test/list/07-linebreaks.json
+++ b/test/list/07-linebreaks.json
@@ -6,7 +6,16 @@
     "insert": "FE | Fix empty spaces"
   },
   {
-    "insert": "\n\nLine1"
+    "insert": "\n"
+  },
+  {
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
+  {
+    "insert": "Line1"
   },
   {
     "insert": "\n",
@@ -24,7 +33,13 @@
     "insert": "Update the fonts"
   },
   {
-    "insert": "\nLine2"
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
+  {
+    "insert": "Line2"
   },
   {
     "insert": "\n",
@@ -51,7 +66,13 @@
     "insert": "Move blocks (single and multi select) up and down via CMD/CTRL + Shift + Up/Down\n"
   },
   {
-    "insert": "\nLine4"
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
+  {
+    "insert": "Line4"
   },
   {
     "insert": "\n",
@@ -69,7 +90,13 @@
     "insert": "Add snap grid to the columns resizing"
   },
   {
-    "insert": "\nLine5"
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
+  {
+    "insert": "Line5"
   },
   {
     "insert": "\n",

--- a/test/list/08-bullet-codeblock.json
+++ b/test/list/08-bullet-codeblock.json
@@ -9,7 +9,16 @@
     "insert": "DB DDL Migration Process"
   },
   {
-    "insert": ":\n\nRun a command to generate a new SQL file under "
+    "insert": ":\n"
+  },
+  {
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
+  {
+    "insert": "Run a command to generate a new SQL file under "
   },
   {
     "insert": "scripts/migrations/bdr",

--- a/test/list/08-checkbox.json
+++ b/test/list/08-checkbox.json
@@ -9,7 +9,13 @@
     }
   },
   {
-    "insert": "\n    Check 1"
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
+  {
+    "insert": "    Check 1"
   },
   {
     "insert": "\n",

--- a/test/list/09-bullet-bottom.json
+++ b/test/list/09-bullet-bottom.json
@@ -1,0 +1,20 @@
+[
+  {
+    "insert": "reply with the following text exactly\n\nfirst line\n"
+  },
+  {
+    "insert": "\n",
+    "attributes": {
+      "blockId": "1234567890"
+    }
+  },
+  {
+    "insert": "bullet on first line\nsecond line\nthird line"
+  },
+  {
+    "insert": "\n",
+    "attributes": {
+      "list": "bullet"
+    }
+  }
+]

--- a/test/list/09-bullet-bottom.md
+++ b/test/list/09-bullet-bottom.md
@@ -1,0 +1,7 @@
+reply with the following text exactly
+
+
+first line
+- bullet on first line
+second line
+third line

--- a/test/mixed/02-paragraph-list.json
+++ b/test/mixed/02-paragraph-list.json
@@ -1,6 +1,11 @@
 [
-  { "insert": "This is a list:" },
-  { "insert": "\n\n" },
+  { "insert": "This is a list:\n" },
+  {
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
   { "insert": "item one" },
   {
     "attributes": {

--- a/test/mixed/03-paragraph-list-paragraph.json
+++ b/test/mixed/03-paragraph-list-paragraph.json
@@ -1,6 +1,11 @@
 [
-  { "insert": "This is a paragraph" },
-  { "insert": "\n\n" },
+  { "insert": "This is a paragraph\n" },
+  {
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
   { "insert": "item one" },
   {
     "attributes": {

--- a/test/mixed/04-list-list.json
+++ b/test/mixed/04-list-list.json
@@ -17,7 +17,12 @@
     },
     "insert": "\n"
   },
-  { "insert": "\n" },
+  {
+    "attributes": {
+      "blockId": "1234567890"
+    },
+    "insert": "\n"
+  },
   {
     "insert": "Item three"
   },

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -4,6 +4,13 @@ import Op from 'quill-delta/dist/Op';
 import Delta from 'quill-delta';
 import { MarkdownToQuill } from '../src/mdToDelta';
 import { defaultCustomHtmlConverter } from '../src/html-converter';
+
+jest.mock('uuid', () => ({
+  v4: () => {
+    return '1234567890';
+  },
+}));
+
 interface Test {
   name: string;
   ops: Op[];


### PR DESCRIPTION
# Summary

linebreaks will be automatically merged in Delta

for example we have:
```
line1

- line2
```
Then they will be merged into a single insert, which is not expect:

```
{insert: "line1\n\nline2"}
{insert: "\n", attributes: { "list" }}
```

Line1 becomes a list item, which is not expected

This PR adds a `blockId`, prevent the inserts be merged.