### PR TITLE
feat: split content in list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/md-to-quill-delta",
-  "version": "1.2.7",
+  "version": "1.2.11",
   "description": "Markdown to Quill Delta",
   "main": "dist/umd/index.js",
   "module": "dist/mdToDelta.js",

--- a/test/list/09-bullet-bottom.json
+++ b/test/list/09-bullet-bottom.json
@@ -1,0 +1,10 @@
+[
+  {
+    "insert": "reply with the following text exactly\n\nfirst line\n\nbullet on first line"
+  },
+  { "insert": "\n", "attributes": { "list": "bullet" } },
+  { "insert": "second line" },
+  { "insert": "\n", "attributes": { "list": "none" } },
+  { "insert": "third line" },
+  { "insert": "\n", "attributes": { "list": "none" } }
+]

--- a/test/list/09-bullet-bottom.md
+++ b/test/list/09-bullet-bottom.md
@@ -1,0 +1,7 @@
+reply with the following text exactly
+
+
+first line
+- bullet on first line
+second line
+third line


### PR DESCRIPTION
Split content in list item.

For example:
```
- line1
line2
line3
```

We need to split into three items

```
{insert:"line1", attributes: { list: "bullet" }}
{insert:"line2", attributes: { list: "none" }}
{insert:"line3", attributes: { list: "none" }}
```