### PR TITLE
fix(docs): change link and table conversions to avoid editor corruptions  

### DIFF
--- a/src/mdToDelta.ts
+++ b/src/mdToDelta.ts
@@ -154,7 +154,7 @@ export class MarkdownToQuill {
             const colNumber = firstRow.children.length;
             const colsInsertStr = new Array(colNumber).fill('\n').join('');
             delta = delta.concat(
-              new Delta().insert(colsInsertStr, { 'table-col': { width: 150 } })
+              new Delta().insert(colsInsertStr, { 'table-col': { width: '150' } })
             );
 
             delta = delta.concat(

--- a/test/link/04-link-with-multiple-lines.json
+++ b/test/link/04-link-with-multiple-lines.json
@@ -1,0 +1,20 @@
+[
+  {
+    "attributes": {
+      "link": "https://placebear.com/g/200/300"
+    },
+    "insert": "click "
+  },
+  {
+    "insert": "\n"
+  },
+  {
+    "attributes": {
+      "link": "https://placebear.com/g/200/300"
+    },
+    "insert": " here"
+  },
+  {
+    "insert": "\n\n"
+  }
+]

--- a/test/link/04-link-with-multiple-lines.md
+++ b/test/link/04-link-with-multiple-lines.md
@@ -1,0 +1,1 @@
+[click \n here\n](https://placebear.com/g/200/300)

--- a/test/table/01-table-simple.json
+++ b/test/table/01-table-simple.json
@@ -3,7 +3,7 @@
     "insert": "\n\n\n",
     "attributes": {
       "table-col": {
-        "width": 150
+        "width": "150"
       }
     }
   },

--- a/test/table/02-table-align.json
+++ b/test/table/02-table-align.json
@@ -3,7 +3,7 @@
     "insert": "\n\n\n",
     "attributes": {
       "table-col": {
-        "width": 150
+        "width": "150"
       }
     }
   },

--- a/test/table/03-table-format.json
+++ b/test/table/03-table-format.json
@@ -3,7 +3,7 @@
     "insert": "\n\n\n",
     "attributes": {
       "table-col": {
-        "width": 150
+        "width": "150"
       }
     }
   },

--- a/test/table/04-tables.json
+++ b/test/table/04-tables.json
@@ -3,7 +3,7 @@
     "insert": "\n\n\n",
     "attributes": {
       "table-col": {
-        "width": 150
+        "width": "150"
       }
     }
   },
@@ -140,7 +140,7 @@
     "insert": "\n\n\n",
     "attributes": {
       "table-col": {
-        "width": 150
+        "width": "150"
       }
     }
   },
@@ -283,7 +283,7 @@
     "insert": "\n\n\n",
     "attributes": {
       "table-col": {
-        "width": 150
+        "width": "150"
       }
     }
   },

--- a/test/table/05-table-with-multiple-line.json
+++ b/test/table/05-table-with-multiple-line.json
@@ -3,7 +3,7 @@
     "insert": "\n\n",
     "attributes": {
       "table-col": {
-        "width": 150
+        "width": "150"
       }
     }
   },


### PR DESCRIPTION
## Overview
the `mdToDelta` file is used by the BE when markdown is passed in the public API to create tasks or docs. We are finding some of our editor corruptions are coming from public API calls or automations, so the goal is to have this function closer match how quill handles a delta.

_ideally_ we would just run the result of this function through an actual Quill instance to iron out the minor changes itself, but Quill expects a real browser environment to run, so for now we are just trying to identify and fix these issues 1 by 1.

Alternative idea that probably wont work (set a tag on API based deltas and let quill re-form it on first open in the FE before throwing corruption errors): https://app.clickup-stg.com/t/333/CLK-603640?comment=98070001964781

## Tasks
- link: https://app.clickup-stg.com/t/333/CLK-603640
- table: https://app.clickup-stg.com/t/333/CLK-580001

## Link
when a link has a trailing `/n`, Quill automatically strips it off the link and moves it to the next line. This causes corruptions because the length of the link text is 1 less than expected.
**fix:** split any links that have `/n` into multiple links with new lines in between them

## Table
Quill expects the width to be a string but our file returns a number. Quill is still able to parse the correct value, but it causes a corruption.

## Testing Plan
#### Before Merge


#### After Merge