### PR TITLE
fix(ai): fix precise linebreak for headings [AI-6310]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@time-loop/md-to-quill-delta",
-  "version": "1.2.15",
+  "version": "1.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@time-loop/md-to-quill-delta",
-      "version": "1.2.15",
+      "version": "1.2.17",
       "license": "BSD-3-Clause",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/md-to-quill-delta",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Markdown to Quill Delta",
   "main": "dist/umd/index.js",
   "module": "dist/mdToDelta.js",

--- a/src/mdToDelta.ts
+++ b/src/mdToDelta.ts
@@ -121,7 +121,7 @@ export class MarkdownToQuill {
       let prevType;
       children.forEach((child, idx) => {
         if (this.isBlock(child.type) && this.isBlock(prevType)) {
-          if (this.options.preciseLineBreak) {
+          if (this.options.preciseLineBreak && (child.type !== 'heading')) {
             const diff = child.position.start.line - this.prevEndLine;
             for (let i = 1; i < diff; i++) {
               delta.insert('\n', this.splitAttributes ?? {});

--- a/test/newline/02-precise-linebreak-with-headings.json
+++ b/test/newline/02-precise-linebreak-with-headings.json
@@ -1,0 +1,44 @@
+[
+  {
+    "attributes": {
+      "bold": true
+    },
+    "insert": "Description"
+  },
+  {
+    "insert": "\n",
+    "attributes": {
+      "header": 1
+    }
+  },
+  {
+    "insert": "\n"
+  },
+  {
+    "attributes": {
+      "bold": true
+    },
+    "insert": "Comments"
+  },
+  {
+    "insert": "\n",
+    "attributes": {
+      "header": 1
+    }
+  },
+  {
+    "insert": "\n"
+  },
+  {
+    "attributes": {
+      "bold": true
+    },
+    "insert": "Conclusion"
+  },
+  {
+    "insert": "\n",
+    "attributes": {
+      "header": 1
+    }
+  }
+]

--- a/test/newline/02-precise-linebreak-with-headings.md
+++ b/test/newline/02-precise-linebreak-with-headings.md
@@ -1,0 +1,9 @@
+# **Description**
+
+
+
+# **Comments**
+
+
+
+# **Conclusion**

--- a/test/newline/02-precise-linebreak-with-headings.options.json
+++ b/test/newline/02-precise-linebreak-with-headings.options.json
@@ -1,0 +1,3 @@
+{
+  "preciseLineBreak": true
+}

--- a/test/newline/03-precise-linebreak.json
+++ b/test/newline/03-precise-linebreak.json
@@ -1,0 +1,26 @@
+[
+  {
+    "insert": "#jcfh869",
+    "attributes": {
+      "link": "http://localhost:4200/t/jcfh869"
+    }
+  },
+  {
+    "insert": "\nTest"
+  },
+  {
+    "insert": "\n",
+    "attributes": {
+      "list": "bullet"
+    }
+  },
+  {
+    "insert": "Test 2"
+  },
+  {
+    "insert": "\n",
+    "attributes": {
+      "list": "bullet"
+    }
+  }
+]

--- a/test/newline/03-precise-linebreak.md
+++ b/test/newline/03-precise-linebreak.md
@@ -1,0 +1,3 @@
+[#jcfh869](http://localhost:4200/t/jcfh869)
+- Test
+- Test 2

--- a/test/newline/03-precise-linebreak.options.json
+++ b/test/newline/03-precise-linebreak.options.json
@@ -1,0 +1,3 @@
+{
+  "preciseLineBreak": true
+}


### PR DESCRIPTION
Previously we were adding extra line breaks when using `preciseLineBreaks` with headings.

Now, if the child type is 'heading,' we no longer add additional line breaks.
