### PR TITLE
fix(ai): fix extra newline under heading [AI-6310]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@time-loop/md-to-quill-delta",
-  "version": "1.2.17",
+  "version": "1.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@time-loop/md-to-quill-delta",
-      "version": "1.2.17",
+      "version": "1.2.20",
       "license": "BSD-3-Clause",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/md-to-quill-delta",
-  "version": "1.2.18",
+  "version": "1.2.20",
   "description": "Markdown to Quill Delta",
   "main": "dist/umd/index.js",
   "module": "dist/mdToDelta.js",

--- a/src/mdToDelta.ts
+++ b/src/mdToDelta.ts
@@ -121,7 +121,7 @@ export class MarkdownToQuill {
       let prevType;
       children.forEach((child, idx) => {
         if (this.isBlock(child.type) && this.isBlock(prevType)) {
-          if (this.options.preciseLineBreak && (child.type !== 'heading')) {
+          if (this.options.preciseLineBreak) {
             const diff = child.position.start.line - this.prevEndLine;
             for (let i = 1; i < diff; i++) {
               delta.insert('\n', this.splitAttributes ?? {});


### PR DESCRIPTION
Previously headings were always getting a new line added below them even if no newline was needed.

Now we don't add additional new lines for headings.
